### PR TITLE
Fixes for Python 3

### DIFF
--- a/plugin/idaconnect/interface/interface.py
+++ b/plugin/idaconnect/interface/interface.py
@@ -38,7 +38,7 @@ class Interface(Module):
                 return widget
         import PyQt5
         PyQt5.QtWidgets.Menu
-        QtWidget
+        # QtWidget
 
     def __init__(self, plugin):
         super(Interface, self).__init__(plugin)

--- a/plugin/idaconnect/plugin.py
+++ b/plugin/idaconnect/plugin.py
@@ -131,9 +131,9 @@ class Plugin(idaapi.plugin_t):
         copyright = "(c) %s" % self.PLUGIN_AUTHORS
 
         prefix = '[IDAConnect] '
-        print prefix + ("-" * 75)
-        print prefix + "%s - %s" % (self.description(), copyright)
-        print prefix + ("-" * 75)
+        print(prefix + ("-" * 75))
+        print(prefix + "%s - %s" % (self.description(), copyright))
+        print(prefix + ("-" * 75))
 
     def term(self):
         """

--- a/plugin/idaconnect/shared/protocol.py
+++ b/plugin/idaconnect/shared/protocol.py
@@ -17,6 +17,11 @@ from twisted.protocols import basic
 
 from packets import Packet, PacketDeferred, Query, Reply, Container
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
+
 
 class Protocol(basic.LineReceiver, object):
     """

--- a/plugin/idaconnect/utilities/misc.py
+++ b/plugin/idaconnect/utilities/misc.py
@@ -48,7 +48,7 @@ def refreshPseudocodeView():
     """
     Refresh the pseudocode view in IDA
     """
-    names = ['Pseudocode-%c' % chr(ord('A') + i) for i in xrange(5)]
+    names = ['Pseudocode-%c' % chr(ord('A') + i) for i in range(5)]
     for name in names:
         widget = idaapi.find_widget(name)
         if widget:

--- a/server/idaconnect/db.py
+++ b/server/idaconnect/db.py
@@ -218,6 +218,6 @@ class Database(object):
         """
         sql = 'insert into {} ({}) values ({});'
         keys = ', '.join(fields.keys())
-        vals = ', '.join(['?' for _ in xrange(len(fields))])
+        vals = ', '.join(['?'] * len(fields))
         return self._conn.runOperation(sql.format(table, keys, vals),
                                        fields.values())


### PR DESCRIPTION
Fixes for flake8 testing of https://github.com/IDAConnect/IDAConnect on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./plugin/idaconnect/plugin.py:134:20: E999 SyntaxError: invalid syntax
        print prefix + ("-" * 75)
                   ^
./plugin/idaconnect/interface/interface.py:41:9: F821 undefined name 'QtWidget'
        QtWidget
        ^
./plugin/idaconnect/shared/protocol.py:182:29: F821 undefined name 'unicode'
        if isinstance(data, unicode):
                            ^
./plugin/idaconnect/utilities/misc.py:51:59: F821 undefined name 'xrange'
    names = ['Pseudocode-%c' % chr(ord('A') + i) for i in xrange(5)]
                                                          ^
./server/idaconnect/db.py:221:40: F821 undefined name 'xrange'
        vals = ', '.join(['?' for _ in xrange(len(fields))])
                                       ^
1     E999 SyntaxError: invalid syntax
4     F821 undefined name 'QtWidget'
5
```